### PR TITLE
Have mouse aim from head instead of feet

### DIFF
--- a/core/src/ggj/escape/systems/PlayerSystem.java
+++ b/core/src/ggj/escape/systems/PlayerSystem.java
@@ -142,7 +142,7 @@ public class PlayerSystem extends EntitySystem  implements ControllerListener {
                 Vector3 mousePos = new Vector3(Gdx.input.getX(), Gdx.input.getY(), 0);
                 Vector3 mouse = cam.camera.unproject(mousePos);
 
-                pl.aiming = new Vector2(mouse.x, mouse.y).sub(pos).nor();
+                pl.aiming = new Vector2(mouse.x, mouse.y).sub(pos).sub(0, 1f).nor();
                 isShooting = Gdx.input.isButtonPressed(Input.Buttons.LEFT);
                 pl.isAiming = true;
 


### PR DESCRIPTION
Mouse aim is calculated from the feet, but bullets are fired from the head, thus bullets don't travel to where the mouse is aiming at.
